### PR TITLE
Allow var-dump v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spryker/console": "^4.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "spryker/rabbit-mq": "^2.0",
-        "symfony/var-dumper": "^4.0|^5.0",
+        "symfony/var-dumper": "^4.0|^5.0|^6.0",
         "spryker/zed-request": "^3.8"
     },
     "require-dev": {

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
@@ -68,7 +68,7 @@ class TableNameFinder
                     $entityNamespace,
                     '\\',
                     $this->nameGenerator->generateName([
-                        $tableEl->attributes->getNamedItem('name')->value,
+                        $tableEl->attributes->getNamedItem('name')->nodeValue,
                         PhpNameGenerator::CONV_METHOD_PHPNAME,
                     ]),
                 ]);


### PR DESCRIPTION
This module is limiting `symfony/var-dumper` to version 5.* and this is causing a bit of dependency hell when trying to upgrade Spryker to use v6 modules.

This PR is just allowing the higher version.